### PR TITLE
Fix manta dtrace errors

### DIFF
--- a/sup.pp
+++ b/sup.pp
@@ -43,6 +43,7 @@ exec { "known_hosts":
 exec { "install-manta":
   command => "/opt/local/bin/npm install -g manta",
   unless  => "/usr/bin/test -f /opt/local/bin/mget",
+  environment => "HOME=/root"
 }
 
 exec { "install-sup-notify":

--- a/sup.pp
+++ b/sup.pp
@@ -9,6 +9,7 @@ package { "gcc49":
 
 package { "gmake":
   ensure => installed,
+  before => Package["nodejs"],
 }
 
 package { "git":


### PR DESCRIPTION
When applying the puppet script for the first time, the manta commands will echo error messages after being installed:

```
{ [Error: Cannot find module './build/Release/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/default/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/Release/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/default/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/Release/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/default/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
```

Setting the HOME environment variable during ``npm intall`` fixes this.