### PR TITLE
Minor syntax fix

### DIFF
--- a/sup.pp
+++ b/sup.pp
@@ -4,7 +4,7 @@ exec { "bash_profile":
 
 exec { "/opt/local/etc/postfix/main.cf":
   command => "/opt/local/bin/curl https://raw.githubusercontent.com/andrewh1978/sup/master/main.cf >/opt/local/etc/postfix/main.cf",
-  before => Service{"postfix"},
+  before => Service["postfix"],
 }
 
 service { "postfix":


### PR DESCRIPTION
```
Error: Could not parse for environment production: Syntax error at '{'; expected '}' at line 7 on node 33cfc1f9-9a3a-e738-f9d0-bae92d13bdcc
```

Changing ``{`` to ``[`` fixed it.