### PR TITLE
Add im-notices tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ export MANTA_USER=<Manta user ID>
 mget /joyentsup/stor/sup/profile.$DC >/root/.profile
 mget /joyentsup/stor/sup/sdc-config.json >/root/toolbox/node_modules/sdc/etc/config.json
 mget /joyentsup/stor/sup/$DC.json >/opt/local/lib/node_modules/sup-notify/etc/dc.json
+mget /joyentsup/stor/sup/im-notices.json >/opt/local/lib/node_modules/im-notices/etc/config.json
 rm -f /root/.ssh/id_rsa
 ```

--- a/sup.pp
+++ b/sup.pp
@@ -33,7 +33,7 @@ exec { "remove-nodejs":
 package { "nodejs":
   ensure => "0.10.48",
   require => Exec["remove-nodejs"],
-  before => [ Exec["install-manta"], Exec["install-sup-notify"], Exec["install-toolbox"] ],
+  before => [ Exec["install-manta"], Exec["install-sup-notify"], Exec["install-toolbox"], Exec["install-im-notices"] ],
 }
 
 package { "p5-libwww":
@@ -96,6 +96,13 @@ exec { "install-toolbox":
   refreshonly => true,
   command => "/opt/local/bin/npm install",
   cwd => "/root/sup-toolbox",
+  environment => "HOME=/root",
+}
+
+exec { "install-im-notices":
+  require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
+  command => "/opt/local/bin/npm install -g git+ssh://git@github.com/joyent/sup-im-notices.git",
+  unless  => "/usr/bin/test -f /opt/local/bin/im-notices",
   environment => "HOME=/root",
 }
 


### PR DESCRIPTION
- Installs ``im-notices`` tool
- ``/joyentsup/stor/sup/profile.{jpc,spc}`` files have been updated in manta
- tested in CoaL and JPC (sup-notify-dev instance)

.profile will need to be re-sourced as a new JIRA_URL environment variable is required by ``im-notices``.

/cc @andrewh1978