### PR TITLE
Install toolbox with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ export MANTA_URL=https://us-east.manta.joyent.com
 export MANTA_USER=<Manta user ID>
 mget /joyentsup/stor/sup/profile.$DC >/root/.profile
 mget /joyentsup/stor/sup/sdc-config.json >/opt/local/lib/toolbox/node_modules/sdc/etc/config.json
-mget /joyentsup/stor/sup/$DC.json >/opt/local/lib/node_modules/toolbox/node_modules/sdc/etc/config.json
+mget /joyentsup/stor/sup/$DC.json >/opt/local/lib/node_modules/sup-notify/etc/dc.json
 mget /joyentsup/stor/sup/im-notices.json >/opt/local/lib/node_modules/im-notices/etc/config.json
 rm -f /root/.ssh/id_rsa
 ```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ export MANTA_KEY_ID=$(ssh-keygen -E md5 -l -f /root/.ssh/id_rsa | cut -b 10-56)
 export MANTA_URL=https://us-east.manta.joyent.com
 export MANTA_USER=<Manta user ID>
 mget /joyentsup/stor/sup/profile.$DC >/root/.profile
-mget /joyentsup/stor/sup/sdc-config.json >/root/toolbox/node_modules/sdc/etc/config.json
-mget /joyentsup/stor/sup/$DC.json >/opt/local/lib/node_modules/sup-notify/etc/dc.json
+mget /joyentsup/stor/sup/sdc-config.json >/opt/local/lib/toolbox/node_modules/sdc/etc/config.json
+mget /joyentsup/stor/sup/$DC.json >/opt/local/lib/node_modules/toolbox/node_modules/sdc/etc/config.json
 mget /joyentsup/stor/sup/im-notices.json >/opt/local/lib/node_modules/im-notices/etc/config.json
 rm -f /root/.ssh/id_rsa
 ```

--- a/sup.pp
+++ b/sup.pp
@@ -55,7 +55,7 @@ package { "manta":
 }
 
 package { "sup-notify":
-  ensure => present,
+  ensure => latest,
   provider => "npm",
   require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
   source => "git+ssh://git@github.com/joyent/sup-notify.git",
@@ -76,14 +76,14 @@ exec { "update-sup-notify-templates":
 }
 
 package { "toolbox":
-  ensure => present,
+  ensure => latest,
   provider => "npm",
   require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
   source => "git+ssh://git@github.com/travispaul/sup-toolbox.git",
 }
 
 package { "im-notices":
-  ensure => present,
+  ensure => latest,
   provider => "npm",
   require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
   source => "git+ssh://git@github.com/joyent/sup-im-notices.git",

--- a/sup.pp
+++ b/sup.pp
@@ -33,7 +33,7 @@ exec { "remove-nodejs":
 package { "nodejs":
   ensure => "0.10.48",
   require => Exec["remove-nodejs"],
-  before => [ Package["manta"], Package["sup-notify"], Exec["install-toolbox"], Package["im-notices"] ],
+  before => [ Package["manta"], Package["sup-notify"], Package["toolbox"], Package["im-notices"] ],
 }
 
 package { "p5-libwww":
@@ -75,27 +75,11 @@ exec { "update-sup-notify-templates":
   cwd => "/opt/local/lib/triton-cloud-notification-templates",
 }
 
-exec { "download-toolbox":
-  require => Package["git"],
-  command => "/opt/local/bin/git clone git@github.com:joyent/sup-toolbox.git",
-  unless => "/usr/bin/test -d /root/sup-toolbox",
-  cwd => "/root",
-  notify => Exec["install-toolbox"],
-}
-
-exec { "update-toolbox":
-  require => Package["git"],
-  command => "/opt/local/bin/git pull",
-  unless => "/usr/bin/test ! -d /root/sup-toolbox",
-  cwd => "/root/sup-toolbox",
-  notify => Exec["install-toolbox"],
-}
-
-exec { "install-toolbox":
-  refreshonly => true,
-  command => "/opt/local/bin/npm install",
-  cwd => "/root/sup-toolbox",
-  environment => "HOME=/root",
+package { "toolbox":
+  ensure => present,
+  provider => "npm",
+  require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
+  source => "git+ssh://git@github.com/travispaul/sup-toolbox.git",
 }
 
 package { "im-notices":
@@ -122,16 +106,4 @@ package { "new-ufds-users":
   provider => "npm",
   require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
   source => "git+ssh://git@github.com:joyent/sup-new-ufds-users.git",
-}
-
-exec { "link-node":
-  require => Exec["download-toolbox"],
-  command => "/opt/local/bin/mkdir -p /root/sup-toolbox/node_modules/sdc/build/node/bin && /opt/local/bin/ln -s /opt/local/bin/node /root/sup-toolbox/node_modules/sdc/build/node/bin/node",
-}
-
-file { "toolbox":
-  path => "/root/toolbox",
-  ensure => "link",
-  target => "/root/sup-toolbox",
-  require => Exec["download-toolbox"],
 }

--- a/sup.pp
+++ b/sup.pp
@@ -55,7 +55,7 @@ package { "manta":
 }
 
 package { "sup-notify":
-  ensure => latest,
+  ensure => present,
   provider => "npm",
   require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
   source => "git+ssh://git@github.com/joyent/sup-notify.git",
@@ -79,11 +79,11 @@ package { "toolbox":
   ensure => latest,
   provider => "npm",
   require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
-  source => "git+ssh://git@github.com/travispaul/sup-toolbox.git",
+  source => "git+ssh://git@github.com/joyent/sup-toolbox.git",
 }
 
 package { "im-notices":
-  ensure => latest,
+  ensure => present,
   provider => "npm",
   require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
   source => "git+ssh://git@github.com/joyent/sup-im-notices.git",
@@ -107,3 +107,4 @@ package { "new-ufds-users":
   require => [ Package["gcc49"], Package["gmake"], Package["git"], Exec["known_hosts"] ],
   source => "git+ssh://git@github.com:joyent/sup-new-ufds-users.git",
 }
+


### PR DESCRIPTION
This change installs toolbox to /opt/local/bin/toolbox. 

I've tested 50/68 commands offered by toolbox and they all worked as expected (some are broken, but they also fail in the same manner on the other sup instances).

